### PR TITLE
Version change and corresponding API changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ repository = "https://github.com/briansmith/ring"
 rust-version = "1.61.0"
 
 # Keep in sync with `links` below.
-#version = "0.17.5"
-version = "0.16.30"
+version = "0.17.5"
 
 # Keep in sync with `version` above.
 #
@@ -24,7 +23,7 @@ version = "0.16.30"
 # build.rs uses this to derive the prefix for FFI symbols and the file names
 # of the FFI libraries, so it must be a valid identifier prefix and a valid
 # filename prefix.
-links = "ring_core_0_16_30"
+links = "ring_core_0_17_5"
 
 include = [
     "LICENSE",
@@ -173,13 +172,13 @@ name = "ring"
 
 [dependencies]
 getrandom = { version = "0.2.10" }
-untrusted = { version = "0.7" } # changed this for compatibility with other users of untrusted
+untrusted = { version = "0.9" }
 
 [target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux", target_os = "windows"))))'.dependencies]
 spin = { version = "0.9.8", default-features = false, features = ["once"] }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
-libc = { version = "0.2.144", default-features = false }
+libc = { version = "0.2.148", default-features = false }
 
 [target.'cfg(all(target_arch = "aarch64", target_os = "windows"))'.dependencies]
 windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_System_Threading"] }
@@ -188,7 +187,7 @@ windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_System_
 wasm-bindgen-test = { version = "0.3.37", default-features = false }
 
 [target.'cfg(any(unix, windows, target_os = "wasi"))'.dev-dependencies]
-libc = { version = "0.2.144", default-features = false }
+libc = { version = "0.2.148", default-features = false }
 
 [build-dependencies]
 cc = { version = "1.0.83", default-features = false }

--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -47,12 +47,10 @@
 //! agreement::agree_ephemeral(
 //!     my_private_key,
 //!     &peer_public_key,
-//!     ring::error::Unspecified,
 //!     |_key_material| {
 //!         // In a real application, we'd apply a KDF to the key material and the
 //!         // public keys (as recommended in RFC 7748) and then derive session
 //!         // keys from the result. We omit all that here.
-//!         Ok(())
 //!     },
 //! )?;
 //!
@@ -244,38 +242,30 @@ impl<B> UnparsedPublicKey<B> {
 /// key material from the key agreement operation and then returns what `kdf`
 /// returns.
 #[inline]
-pub fn agree_ephemeral<B: AsRef<[u8]>, F, R, E>(
+pub fn agree_ephemeral<B: AsRef<[u8]>, R>(
     my_private_key: EphemeralPrivateKey,
     peer_public_key: &UnparsedPublicKey<B>,
-    error_value: E,
-    kdf: F,
-) -> Result<R, E> 
-where
-    F: FnOnce(&[u8]) -> Result<R, E>,
-{
+    kdf: impl FnOnce(&[u8]) -> R,
+) -> Result<R, error::Unspecified> {
     let peer_public_key = UnparsedPublicKey {
         algorithm: peer_public_key.algorithm,
         bytes: peer_public_key.bytes.as_ref(),
     };
-    agree_ephemeral_(my_private_key, peer_public_key, error_value, kdf)
+    agree_ephemeral_(my_private_key, peer_public_key, kdf)
 }
 
-fn agree_ephemeral_<F, R, E>(
+fn agree_ephemeral_<R>(
     my_private_key: EphemeralPrivateKey,
     peer_public_key: UnparsedPublicKey<&[u8]>,
-    error_value: E,
-    kdf: F,
- ) -> Result<R, E>
-where
-    F: FnOnce(&[u8]) -> Result<R, E>,
-{
+    kdf: impl FnOnce(&[u8]) -> R,
+) -> Result<R, error::Unspecified> {
     // NSA Guide Prerequisite 1.
     //
     // The domain parameters are hard-coded. This check verifies that the
     // peer's public key's domain parameters match the domain parameters of
     // this private key.
     if peer_public_key.algorithm != my_private_key.algorithm {
-        return Err(error_value);
+        return Err(error::Unspecified);
     }
 
     let alg = &my_private_key.algorithm;
@@ -301,12 +291,11 @@ where
         shared_key,
         &my_private_key.private_key,
         untrusted::Input::from(peer_public_key.bytes),
-    )
-    .map_err(|_| error_value)?;
+    )?;
 
     // NSA Guide Steps 5 and 6.
     //
     // Again, we have a pretty liberal interpretation of the NIST's spec's
     // "Destroy" that doesn't meet the NSA requirement to "zeroize."
-    kdf(shared_key)
+    Ok(kdf(shared_key))
 }

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -262,8 +262,7 @@ impl core::fmt::Debug for Digest {
 
 /// A digest algorithm.
 pub struct Algorithm {
-    /// The length of a finalized digest.
-    pub output_len: usize, // changed to pub for compatibility with previous version
+    output_len: usize,
     chaining_len: usize,
     block_len: usize,
 

--- a/src/ec/suite_b/ecdsa/signing.rs
+++ b/src/ec/suite_b/ecdsa/signing.rs
@@ -105,6 +105,7 @@ impl EcdsaKeyPair {
     pub fn from_pkcs8(
         alg: &'static EcdsaSigningAlgorithm,
         pkcs8: &[u8],
+        rng: &dyn rand::SecureRandom,
     ) -> Result<Self, error::KeyRejected> {
         let key_pair = ec::suite_b::key_pair_from_pkcs8(
             alg.curve,
@@ -112,9 +113,7 @@ impl EcdsaKeyPair {
             untrusted::Input::from(pkcs8),
             cpu::features(),
         )?;
-        // This was changed to a parameter, regressed for compatibility with previous version
-        let rng = rand::SystemRandom::new();
-        Self::new(alg, key_pair, &rng)
+        Self::new(alg, key_pair, rng)
     }
 
     /// Constructs an ECDSA key pair from the private key and public key bytes


### PR DESCRIPTION
We want everything on the same version of ring. Recent updates to dependencies started using v0.17, so I'm getting other dependencies to do so too. 
This PR upissues our patched version to 0.17.5, in line with the latest released version.
In fact, it undoes a regression to 0.16 which was previously in place to satisfy the needs of dependencies using the old version. So, it's a step closer to bringing our version in line with the original (the only difference is the changes for MIPS support).